### PR TITLE
fix: prevent infinite recursion in `order_by` validation with `replace_invalid_params?: true`

### DIFF
--- a/lib/ash_pagify/validation.ex
+++ b/lib/ash_pagify/validation.ex
@@ -629,19 +629,34 @@ defmodule AshPagify.Validation do
     end
   end
 
+  # Validates each order_by entry on its own, keeping the ones that parse
+  # and recording an error for each that doesn't.
+  #
+  # The previous implementation removed the failing entry with
+  # `List.delete(order_by, error.field)` and recursed. But `error.field` is
+  # the parsed field name, not the raw entry — for a direction-prefixed
+  # entry (`"-non_existent"` → field `"non_existent"`) or a related path
+  # (`"author.name"` → field `"name"`) the two differ, so nothing was
+  # removed and the function recursed on identical input forever, appending
+  # an error every iteration (unbounded memory growth). Since `order_by`
+  # comes from user-controllable params, that made a single crafted value
+  # (e.g. `?order_by[]=author.name`) a denial-of-service against any caller
+  # using `replace_invalid_params?: true`.
+  #
+  # Parsing per entry sidesteps the `error.field`/entry mismatch entirely
+  # and always terminates.
   defp replace_invalid_order_by(order_by, params, resource) do
-    case Ash.Sort.parse_input(resource, order_by) do
-      {:ok, order_by} ->
-        if order_by == [] do
-          Map.put(params, :order_by, nil)
-        else
-          Map.put(params, :order_by, order_by)
+    {valid_reversed, params} =
+      Enum.reduce(order_by, {[], params}, fn entry, {valid, params} ->
+        case Ash.Sort.parse_input(resource, [entry]) do
+          {:ok, parsed} -> {Enum.reverse(parsed, valid), params}
+          {:error, error} -> {valid, add_error(params, :order_by, error)}
         end
+      end)
 
-      {:error, error} ->
-        params = add_error(params, :order_by, error)
-        order_by = List.delete(order_by, error.field)
-        replace_invalid_order_by(order_by, params, resource)
+    case Enum.reverse(valid_reversed) do
+      [] -> Map.put(params, :order_by, nil)
+      order_by -> Map.put(params, :order_by, order_by)
     end
   end
 

--- a/test/ash_pagify/validation_test.exs
+++ b/test/ash_pagify/validation_test.exs
@@ -604,6 +604,46 @@ defmodule AshPagify.ValidationTest do
                  replace_invalid_params?: true
                )
     end
+
+    # Regression: entries whose parsed field name differs from the raw entry
+    # (a direction prefix, or a dotted path) used to loop forever under
+    # replace_invalid_params?: true, because the recovery removed
+    # `error.field` from the list and `error.field` never matched the entry.
+    # Since order_by is user-controllable, that was a DoS. The timeouts make
+    # a regression fail fast instead of hanging the whole suite.
+
+    @tag timeout: 5_000
+    test "replaces a direction-prefixed invalid entry without looping" do
+      assert %{
+               order_by: [name: :desc],
+               errors: [order_by: [%NoSuchField{}]]
+             } =
+               Validation.validate_order_by(%{order_by: ["-name", "-non_existent"]},
+                 for: Post,
+                 replace_invalid_params?: true
+               )
+    end
+
+    @tag timeout: 5_000
+    test "replaces a dotted-path invalid entry without looping" do
+      assert %{
+               order_by: nil,
+               errors: [order_by: [_error]]
+             } =
+               Validation.validate_order_by(%{order_by: ["non_existent.name"]},
+                 for: Post,
+                 replace_invalid_params?: true
+               )
+    end
+
+    @tag timeout: 5_000
+    test "drops every invalid entry and keeps the valid ones" do
+      assert %{order_by: [name: :asc]} =
+               Validation.validate_order_by(%{order_by: ["name", "-bogus", "x.y"]},
+                 for: Post,
+                 replace_invalid_params?: true
+               )
+    end
   end
 
   describe "validate_pagination/2" do


### PR DESCRIPTION
## Contributor checklist

- [x] Bug fixes include regression tests

## What's wrong

`Validation.replace_invalid_order_by/3` (the recovery path taken when
`replace_invalid_params?: true` and an `order_by` value fails to parse) can
recurse forever on a single call:

```elixir
{:error, error} ->
  params = add_error(params, :order_by, error)
  order_by = List.delete(order_by, error.field)   # ← assumes error.field == the entry
  replace_invalid_order_by(order_by, params, resource)
```

It removes the failing entry with `List.delete(order_by, error.field)`, but
`error.field` is the **parsed field name**, not the raw list entry. They
differ whenever the entry carries a direction prefix or is a related path:

| `order_by` entry | `error.field` | `List.delete` result | outcome |
| --- | --- | --- | --- |
| `"non_existent"` | `"non_existent"` | entry removed | terminates ✅ |
| `"-non_existent"` | `"non_existent"` | **nothing removed** | loops forever ♾️ |
| `"author.name"` | `"name"` | **nothing removed** | loops forever ♾️ |

When nothing is removed, the next iteration parses the identical list, gets
the identical error, and recurses again — while `add_error/3` prepends a new
error every pass, so memory grows without bound until the VM dies.

## Why it matters

`order_by` is populated from request params (that's the whole point of
`AshPagify`'s URL round-tripping), and `replace_invalid_params?: true` is the
option you reach for precisely to tolerate malformed user input. So on any
endpoint that passes params through `validate!`/`validate_and_run` with that
option set, a single crafted query string —

```
?order_by[]=author.name
```

— sends the request process into an unbounded-memory infinite loop and can
take the node down. No valid field name or schema knowledge is required
(`?order_by[]=bogus.name` works just as well), so it's remotely triggerable
resource exhaustion (CWE-674 / CWE-400).

The existing test coverage missed it because its one invalid case,
`"--name,non_existent"`, uses an unprefixed, non-dotted invalid entry — the
only shape where `error.field` happens to string-match the entry and
`List.delete` succeeds.

## The fix

Validate each `order_by` entry independently: keep the ones that parse,
record an error for each that doesn't. This removes the `error.field`↔entry
matching assumption entirely and always terminates — a valid entry is never
dropped, and an invalid one is dropped exactly once whatever its shape.

Behavior is otherwise unchanged: the existing `"--name,non_existent"` case
still returns `[name: :desc_nils_last]` with a `NoSuchField` error, and the
"all entries invalid → `order_by: nil`" contract is preserved.

## Tests

Three regression tests added to `validate_order_by/2`, each tagged
`@tag timeout: 5_000` so a regression fails fast instead of hanging the
suite:

- direction-prefixed invalid entry (`["-name", "-non_existent"]`)
- dotted-path invalid entry (`["non_existent.name"]`)
- mixed valid + multiple invalid (`["name", "-bogus", "x.y"]`)

Against the current `main` code all three time out at 5s (the infinite
loop); with the fix they pass in <1ms, alongside the full existing suite
(`33 doctests, 79 tests, 0 failures`).

## Note on disclosure

This is a remotely-triggerable denial of service, but the fix is small, the
impact is availability-only, and there's no security-contact channel on the
repo — so I'm reporting it directly here. Happy to adjust if you'd prefer to
handle it differently.
